### PR TITLE
Fix rewrite configuration on Firebase Hosting for SPA

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,10 +1,12 @@
 {
   "hosting": {
     "public": "build",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
     ]
   }
 }


### PR DESCRIPTION
Currently, if we access the specific URL outside of the index, for example, https://ioxindonesia.com/speakers, it's showing us a 404 page. It's because we forgot to configure the [rewrite configuration for SPA](https://firebase.google.com/docs/hosting/full-config#rewrites). Here I configure it to rewrite all requests to `index.html`.